### PR TITLE
Update changes in API V3: takeprofit and stoploss 

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -18,6 +18,7 @@ from lnmarkets_sdk.v3.models.futures_data import (
 from lnmarkets_sdk.v3.models.futures_isolated import (
     GetClosedTradesParams,
     GetIsolatedFundingFeesParams,
+    UpdateTakeprofitParams,
 )
 from lnmarkets_sdk.v3.models.oracle import GetLastPriceParams
 
@@ -32,7 +33,7 @@ async def example_public_endpoints():
 
     # Create client without authentication for public endpoints
     # The httpx.AsyncClient is created once and reuses connections
-    async with LNMClient(APIClientConfig(network="testnet4")) as client:
+    async with LNMClient(APIClientConfig(network="mainnet")) as client:
         # All these requests share the same connection pool
         print("\n🔄 Making multiple requests with connection reuse...")
 
@@ -220,6 +221,12 @@ async def example_authenticated_endpoints():
             print(f"New order: {new_order}")
         except Exception as e:
             print(f"Error: {e}")
+
+        print("\n --- Update take profit ---")
+        trade_id = "41ee6f7e-7cee-4c3b-b9f3-962d4b3b97c6"
+        params = UpdateTakeprofitParams(id=trade_id, value=100_000)
+        updated = await client.futures.isolated.update_takeprofit(params)
+        print(f"New take profit: {updated.takeprofit}")
 
 
 async def main():

--- a/src/lnmarkets_sdk/v3/_internal/models.py
+++ b/src/lnmarkets_sdk/v3/_internal/models.py
@@ -3,11 +3,10 @@ from typing import Any, Literal
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation, ValidationError
 from pydantic.alias_generators import to_camel
-from pydantic.types import UUID4
 
 type APINetwork = Literal["mainnet", "testnet4"]
 type APIMethod = Literal["GET", "POST", "PUT"]
-type UUID = UUID4
+type UUID = str
 
 
 class BaseConfig:

--- a/src/lnmarkets_sdk/v3/http/client/futures/isolated.py
+++ b/src/lnmarkets_sdk/v3/http/client/futures/isolated.py
@@ -236,7 +236,7 @@ class FuturesIsolatedClient:
         from lnmarkets_sdk.v3.models.futures_isolated import UpdateStoplossParams
 
         async with LNMClient(config) as client:
-            params = UpdateStoplossParams(id=trade_id, stoploss=90_000)
+            params = UpdateStoplossParams(id=trade_id, value=90000)
             updated = await client.futures.isolated.update_stoploss(params)
             print(f"New stop loss: {updated.stoploss}")
         ```
@@ -258,11 +258,12 @@ class FuturesIsolatedClient:
         from lnmarkets_sdk.v3.models.futures_isolated import UpdateTakeprofitParams
 
         async with LNMClient(config) as client:
-            params = UpdateTakeprofitParams(id=trade_id, takeprofit=110_000)
+            params = UpdateTakeprofitParams(id=trade_id, value=10000)
             updated = await client.futures.isolated.update_takeprofit(params)
             print(f"New take profit: {updated.takeprofit}")
         ```
         """
+        print(f"params: {params}")
         return await self._client.request(
             "PUT",
             "/futures/isolated/trade/takeprofit",

--- a/src/lnmarkets_sdk/v3/models/futures_isolated.py
+++ b/src/lnmarkets_sdk/v3/models/futures_isolated.py
@@ -135,12 +135,12 @@ class CloseTradeParams(BaseModel, BaseConfig):
 
 class UpdateStoplossParams(BaseModel, BaseConfig):
     id: UUID = Field(..., description="Trade ID")
-    stoploss: float = Field(..., description="New stop loss price level")
+    value: float = Field(..., description="New stop loss price level")
 
 
 class UpdateTakeprofitParams(BaseModel, BaseConfig):
     id: UUID = Field(..., description="Trade ID")
-    takeprofit: float = Field(..., description="New take profit price level")
+    value: float = Field(..., description="New take profit price level")
 
 
 class GetClosedTradesParams(FromToLimitParams): ...

--- a/src/lnmarkets_sdk/v3/tests/test_integration.py
+++ b/src/lnmarkets_sdk/v3/tests/test_integration.py
@@ -354,7 +354,6 @@ class TestFuturesIntegration:
             assert isinstance(ticker.prices, list)
             if len(ticker.prices) > 0:
                 price_bucket = ticker.prices[0]
-                print(price_bucket)
                 assert price_bucket.max_size > 0
                 assert price_bucket.min_size >= 0
                 if price_bucket.ask_price is not None:
@@ -621,7 +620,7 @@ class TestFuturesIsolatedIntegration:
             running_trades = await client.futures.isolated.get_running_trades()
             if len(running_trades) > 0:
                 trade = running_trades[0]
-                params = UpdateStoplossParams(id=trade.id, stoploss=50_000)
+                params = UpdateStoplossParams(id=trade.id, value=50_000)
                 updated = await client.futures.isolated.update_stoploss(params)
                 assert updated.id == trade.id
                 assert updated.running is True
@@ -640,7 +639,7 @@ class TestFuturesIsolatedIntegration:
             running_trades = await client.futures.isolated.get_running_trades()
             if len(running_trades) > 0:
                 trade = running_trades[0]
-                params = UpdateTakeprofitParams(id=trade.id, takeprofit=150_000)
+                params = UpdateTakeprofitParams(id=trade.id, value=150_000)
                 updated = await client.futures.isolated.update_takeprofit(params)
                 assert updated.id == trade.id
                 assert updated.running is True


### PR DESCRIPTION
## Description
- input field `stoploss` and `takeprofit` are now named `value`
- remove validation for uuid, uuid is now just a string
- fixes #13 