### PR TITLE
Fix link formatting in API documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ client.synthetic_usd.new_swap()   # 🔒
 
 ## API Reference
 
-For full API documentation, see: [LNM API v3 Documentation](https://api.lnmarkets.com/v3)
+For full API documentation, see: [LNM API v3 Documentation](https://api.lnmarkets.com/v3/)
 
 ## Contributing
 


### PR DESCRIPTION
alternatively, you could tweak the website so it doesn't require the trailing slash...