### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,14 +16,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.13
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "latest"
           enable-cache: true


### PR DESCRIPTION
The ln-markets org Actions policy enforces `shaPinningRequired` — every action ref must be a full-length commit SHA. Pins the three workflow actions to their latest releases by SHA:

- `actions/checkout` → v7.0.0
- `actions/setup-python` → v6.3.0 (major bump from v5)
- `astral-sh/setup-uv` → v8.3.2 (major bump from v4)

All are already permitted by the org allowlist (GitHub-owned + `astral-sh/*`), so no policy change is needed for this repo.