### PR TITLE
migrating from testnet4 to signet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy to `.env` — loaded by examples via python-dotenv and by the
+# integration tests. Examples default to signet; pass --mainnet to opt in.
+
+# Signet credentials (default network).
+SIGNET_API_KEY=
+SIGNET_API_SECRET=
+SIGNET_API_PASSPHRASE=
+
+# Mainnet credentials (used with --mainnet).
+MAINNET_API_KEY=
+MAINNET_API_SECRET=
+MAINNET_API_PASSPHRASE=

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,6 +43,6 @@ jobs:
           uv run --isolated --python=3.13 pytest
           uv run --isolated --python=3.14 pytest
         env:
-          TESTNET4_API_KEY: ${{ secrets.TESTNET4_API_KEY }}
-          TESTNET4_API_KEY_SECRET: ${{ secrets.TESTNET4_API_KEY_SECRET }}
-          TESTNET4_API_KEY_PASSPHRASE: ${{ secrets.TESTNET4_API_KEY_PASSPHRASE }}
+          SIGNET_API_KEY: ${{ secrets.SIGNET_API_KEY }}
+          SIGNET_API_SECRET: ${{ secrets.SIGNET_API_SECRET }}
+          SIGNET_API_PASSPHRASE: ${{ secrets.SIGNET_API_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-07-16
+
+### Added
+
+- Automatic retry with exponential backoff for transient failures. `LNMClient` now retries `503`/`502`/`504`/`429` responses and connection-phase transport errors (`ConnectError`, `ConnectTimeout`, `PoolTimeout`), honoring a `Retry-After` header on `429`. Read/write timeouts are deliberately not retried, so non-idempotent trades cannot be double-submitted. The auth signature is regenerated on every attempt so its timestamp stays fresh across backoff delays.
+- Retry configuration on `APIClientConfig`: `max_retries` (default `3`), `retry_base_delay` (default `1.0`s), `retry_max_delay` (default `8.0`s). Set `max_retries=0` to disable retrying. The base delay defaults to the rate-limit window so retries never trigger a `429`.
+- `tenacity` dependency (backoff engine).
+
+### Changed
+
+- Migrated the test/dev network from `testnet4` to `signet`. The `APINetwork` type is now `"mainnet" | "signet"` (was `"testnet4"`) and the resolved host is `api.signet.lnmarkets.com`. Pass `network="signet"` instead of `network="testnet4"`.
+- Integration tests now guarantee cleanup and guard against low funds: a session teardown cancels resting orders/trades, closes running trades and the cross position, and returns cross margin to the balance (best-effort, never fails the suite); a balance-floor guard skips trading tests when signet funds run low instead of failing with opaque insufficient-margin errors.
+
+## [0.1.3] - 2026-07-03
+
+No user-facing library changes; identical behavior to 0.1.2 (release and CI tooling only).
+
 ## [0.1.2] - 2026-07-02
 
 ### Added

--- a/examples/rest_v3.py
+++ b/examples/rest_v3.py
@@ -3,14 +3,14 @@
 Creds loaded from `.env` via `python-dotenv`.
 
 Run:
-    uv run examples/rest_v3.py                  # public-only, testnet4
-    uv run examples/rest_v3.py --auth           # authenticated, testnet4
+    uv run examples/rest_v3.py                  # public-only, signet
+    uv run examples/rest_v3.py --auth           # authenticated, signet
     uv run examples/rest_v3.py --mainnet
     uv run examples/rest_v3.py --mainnet --auth
 
 Authenticated run reads creds by network:
-    mainnet  -> MAINNET_API_KEY, MAINNET_API_KEY_SECRET, MAINNET_API_KEY_PASSPHRASE
-    testnet4 -> TESTNET4_API_KEY, TESTNET4_API_KEY_SECRET, TESTNET4_API_KEY_PASSPHRASE
+    mainnet  -> MAINNET_API_KEY, MAINNET_API_SECRET, MAINNET_API_PASSPHRASE
+    signet -> SIGNET_API_KEY, SIGNET_API_SECRET, SIGNET_API_PASSPHRASE
 """
 
 import asyncio
@@ -43,7 +43,7 @@ from lnmarkets_sdk.rest.v3.models.futures_isolated import (
 )
 from lnmarkets_sdk.rest.v3.models.oracle import GetLastPriceParams
 
-Network = Literal["mainnet", "testnet4"]
+Network = Literal["mainnet", "signet"]
 
 load_dotenv()
 
@@ -353,7 +353,7 @@ async def example_authenticated_endpoints(network: Network):
 
 async def main():
     """Run all examples."""
-    network: Network = "mainnet" if "--mainnet" in sys.argv else "testnet4"
+    network: Network = "mainnet" if "--mainnet" in sys.argv else "signet"
     want_auth = "--auth" in sys.argv
 
     print("\n" + "=" * 80)

--- a/examples/stream_v1.py
+++ b/examples/stream_v1.py
@@ -3,19 +3,19 @@
 RPC methods covered: hello, ping, time, authenticate, whoami,
                      subscribe, unsubscribe, unsubscribe_all.
 
-Run (public-only, mainnet):
+Run (public-only, signet):
     uv run examples/stream_v1.py
 
 Authenticated run reads creds by network:
-    mainnet  -> MAINNET_API_KEY, MAINNET_API_KEY_SECRET, MAINNET_API_KEY_PASSPHRASE
-    testnet4 -> TESTNET4_API_KEY, TESTNET4_API_KEY_SECRET, TESTNET4_API_KEY_PASSPHRASE
+    signet  -> SIGNET_API_KEY, SIGNET_API_SECRET, SIGNET_API_PASSPHRASE
+    mainnet -> MAINNET_API_KEY, MAINNET_API_SECRET, MAINNET_API_PASSPHRASE
 
 Creds loaded from `.env` via `python-dotenv`:
     uv run examples/stream_v1.py --auth
 
-Defaults to mainnet. Pass --testnet4 to opt in:
-    uv run examples/stream_v1.py --testnet4
-    uv run examples/stream_v1.py --testnet4 --auth
+Defaults to signet. Pass --mainnet to opt in:
+    uv run examples/stream_v1.py --mainnet
+    uv run examples/stream_v1.py --mainnet --auth
 """
 
 from __future__ import annotations
@@ -45,17 +45,17 @@ load_dotenv()
 
 
 def resolve_creds(network: str) -> tuple[str, str, str]:
-    if network == "testnet4":
+    if network == "signet":
         key_var, secret_var, pass_var = (
-            "TESTNET4_API_KEY",
-            "TESTNET4_API_KEY_SECRET",
-            "TESTNET4_API_KEY_PASSPHRASE",
+            "SIGNET_API_KEY",
+            "SIGNET_API_SECRET",
+            "SIGNET_API_PASSPHRASE",
         )
     else:
         key_var, secret_var, pass_var = (
             "MAINNET_API_KEY",
-            "MAINNET_API_KEY_SECRET",
-            "MAINNET_API_KEY_PASSPHRASE",
+            "MAINNET_API_SECRET",
+            "MAINNET_API_PASSPHRASE",
         )
     key = os.environ.get(key_var)
     secret = os.environ.get(secret_var)
@@ -71,7 +71,7 @@ def resolve_creds(network: str) -> tuple[str, str, str]:
 
 
 async def main() -> None:
-    network = "mainnet" if "--mainnet" in sys.argv else "testnet4"
+    network = "mainnet" if "--mainnet" in sys.argv else "signet"
     want_auth = "--auth" in sys.argv
 
     if want_auth:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "websockets>=12.0",
     "orjson>=3.10.0",
     "pygments>=2.20.0",
+    "tenacity>=9.1.4",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 urls = { "Homepage" = "https://github.com/ln-markets/sdk-python", "Repository" = "https://github.com/ln-markets/sdk-python", "Bug Tracker" = "https://github.com/ln-markets/sdk-python/issues" }
 
 name = "lnmarkets-sdk"
-version = "0.1.3"
+version = "0.1.4"
 description = "LN Markets API Python SDK"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/lnmarkets_sdk/rest/v3/_internal/__init__.py
+++ b/src/lnmarkets_sdk/rest/v3/_internal/__init__.py
@@ -7,9 +7,39 @@ from urllib.parse import urlencode
 
 import httpx
 from pydantic import BaseModel
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from .models import APIAuthContext, APIMethod
 from .utils import create_auth_headers, prepare_params
+
+# Statuses where the server signals it did NOT process the request, so a retry
+# is safe from double-submitting a non-idempotent trade. 503 = "Trading engine
+# temporarily unavailable", 502/504 = gateway could not reach upstream,
+# 429 = rate limited.
+_RETRYABLE_STATUS = frozenset({429, 502, 503, 504})
+
+# Connection-phase transport errors only: the request never reached the server,
+# so retrying cannot duplicate a side effect. Read/Write timeouts are excluded
+# on purpose — the server may already have processed the request.
+_RETRYABLE_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+)
+
+
+class _RetryableStatus(Exception):
+    """Internal signal: response carries a status code worth retrying."""
+
+    def __init__(self, response: httpx.Response):
+        super().__init__(f"Retryable status {response.status_code}")
+        self.response = response
 
 
 class BaseClient:
@@ -21,12 +51,22 @@ class BaseClient:
         timeout: float,
         auth: APIAuthContext | None = None,
         custom_headers: dict[str, str] | None = None,
+        max_retries: int = 3,
+        retry_base_delay: float = 1.0,
+        retry_max_delay: float = 8.0,
     ):
         self.base_url = base_url
         self.timeout = timeout
         self.auth = auth
         self.custom_headers = custom_headers or {}
+        self.max_retries = max_retries
+        self.retry_base_delay = retry_base_delay
         self._client: httpx.AsyncClient | None = None
+        # Exponential backoff with full jitter; `initial` doubles as the floor
+        # so the first retry never fires faster than the rate-limit window.
+        self._backoff = wait_exponential_jitter(
+            initial=retry_base_delay, max=retry_max_delay
+        )
 
     async def __aenter__(self) -> "BaseClient":
         """Enter async context manager."""
@@ -42,6 +82,22 @@ class BaseClient:
         if self._client:
             await self._client.aclose()
 
+    def _wait(self, retry_state: RetryCallState) -> float:
+        """Backoff wait, honoring a 429 Retry-After header when present."""
+        outcome = retry_state.outcome
+        if outcome is not None and outcome.failed:
+            exc = outcome.exception()
+            if isinstance(exc, _RetryableStatus) and exc.response.status_code == 429:
+                retry_after = exc.response.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        # Never wait less than the base delay so a retry can't
+                        # itself trip the rate limit.
+                        return max(float(retry_after), self.retry_base_delay)
+                    except ValueError:
+                        pass  # HTTP-date form unsupported; fall back to backoff.
+        return self._backoff(retry_state)
+
     async def request(
         self,
         method: APIMethod,
@@ -49,36 +105,70 @@ class BaseClient:
         params: BaseModel | Mapping[str, object] | None = None,
         credentials: bool = False,
     ) -> httpx.Response:
-        """Make HTTP request and return response."""
+        """Make HTTP request and return response, retrying transient failures."""
         if not self._client:
             raise RuntimeError("Client must be used within async context manager")
 
         params_dict = prepare_params(params)
-        headers: dict[str, str] = {}
 
-        if credentials:
-            if not self.auth:
-                raise ValueError("Authentication required but no credentials provided")
+        async def _send() -> httpx.Response:
+            client = self._client
+            if client is None:
+                raise RuntimeError("Client must be used within async context manager")
 
-            data = ""
-            if params_dict:
-                if method in ("GET", "DELETE"):
-                    data = f"?{urlencode(params_dict)}"
-                    data = re.sub(r"=(True)", "=true", data)
-                    data = re.sub(r"=(False)", "=false", data)
-                else:
-                    data = json.dumps(params_dict, separators=(",", ":"))
-                    headers.update({"Content-Type": "application/json"})
+            headers: dict[str, str] = {}
+            if credentials:
+                if not self.auth:
+                    raise ValueError(
+                        "Authentication required but no credentials provided"
+                    )
 
-            auth_headers = create_auth_headers(self.auth, method, f"/v3{path}", data)
-            headers.update(auth_headers)
+                data = ""
+                if params_dict:
+                    if method in ("GET", "DELETE"):
+                        data = f"?{urlencode(params_dict)}"
+                        data = re.sub(r"=(True)", "=true", data)
+                        data = re.sub(r"=(False)", "=false", data)
+                    else:
+                        data = json.dumps(params_dict, separators=(",", ":"))
+                        headers.update({"Content-Type": "application/json"})
 
-        # Use httpx native parameter handling
-        if method in ("GET", "DELETE"):
-            return await self._client.request(
-                method, path, params=params_dict, headers=headers if headers else None
-            )
-        else:
-            return await self._client.request(
-                method, path, json=params_dict, headers=headers if headers else None
-            )
+                # Re-signed on every attempt so the timestamp stays fresh across
+                # backoff delays (the signature is time-based).
+                auth_headers = create_auth_headers(
+                    self.auth, method, f"/v3{path}", data
+                )
+                headers.update(auth_headers)
+
+            # Use httpx native parameter handling
+            if method in ("GET", "DELETE"):
+                response = await client.request(
+                    method, path, params=params_dict, headers=headers or None
+                )
+            else:
+                response = await client.request(
+                    method, path, json=params_dict, headers=headers or None
+                )
+
+            if response.status_code in _RETRYABLE_STATUS:
+                raise _RetryableStatus(response)
+            return response
+
+        if self.max_retries <= 0:
+            try:
+                return await _send()
+            except _RetryableStatus as exc:
+                return exc.response
+
+        retryer = AsyncRetrying(
+            stop=stop_after_attempt(self.max_retries + 1),
+            wait=self._wait,
+            retry=retry_if_exception_type((*_RETRYABLE_EXCEPTIONS, _RetryableStatus)),
+            reraise=True,
+        )
+        try:
+            return await retryer(_send)
+        except _RetryableStatus as exc:
+            # Retries exhausted: hand the final response to the normal
+            # error-parsing path so callers still get an APIException.
+            return exc.response

--- a/src/lnmarkets_sdk/rest/v3/_internal/models.py
+++ b/src/lnmarkets_sdk/rest/v3/_internal/models.py
@@ -40,6 +40,27 @@ class APIClientConfig(BaseModel):
     hostname: str | None = None
     custom_headers: dict[str, str] | None = None
     timeout: float = Field(default=30.0, gt=0, description="Request timeout in seconds")
+    max_retries: int = Field(
+        default=3,
+        ge=0,
+        description=(
+            "Retry attempts for transient failures (503/502/504/429 and "
+            "connection errors). 0 disables retrying."
+        ),
+    )
+    retry_base_delay: float = Field(
+        default=1.0,
+        gt=0,
+        description=(
+            "Base backoff delay in seconds. Keep >= the rate-limit window "
+            "(1s public / 0.2s auth) so retries never trigger a 429."
+        ),
+    )
+    retry_max_delay: float = Field(
+        default=8.0,
+        gt=0,
+        description="Upper bound in seconds for a single backoff wait.",
+    )
 
 
 class APIError(BaseModel, BaseConfig):

--- a/src/lnmarkets_sdk/rest/v3/_internal/models.py
+++ b/src/lnmarkets_sdk/rest/v3/_internal/models.py
@@ -4,7 +4,7 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation, ValidationError
 from pydantic.alias_generators import to_camel
 
-type APINetwork = Literal["mainnet", "testnet4"]
+type APINetwork = Literal["mainnet", "signet"]
 type APIMethod = Literal["GET", "POST", "PUT", "DELETE"]
 type UUID = str
 

--- a/src/lnmarkets_sdk/rest/v3/_internal/utils.py
+++ b/src/lnmarkets_sdk/rest/v3/_internal/utils.py
@@ -71,7 +71,7 @@ def create_auth_headers(
 def get_hostname(network: APINetwork) -> str:
     """Get API hostname based on network."""
     return (
-        "api.testnet4.lnmarkets.com" if network == "testnet4" else "api.lnmarkets.com"
+        "api.signet.lnmarkets.com" if network == "signet" else "api.lnmarkets.com"
     )
 
 

--- a/src/lnmarkets_sdk/rest/v3/http/client/__init__.py
+++ b/src/lnmarkets_sdk/rest/v3/http/client/__init__.py
@@ -78,6 +78,9 @@ class LNMClient:
             timeout=config.timeout,
             auth=auth,
             custom_headers=config.custom_headers,
+            max_retries=config.max_retries,
+            retry_base_delay=config.retry_base_delay,
+            retry_max_delay=config.retry_max_delay,
         )
 
         self.account = AccountClient(self)

--- a/src/lnmarkets_sdk/rest/v3/tests/test_integration.py
+++ b/src/lnmarkets_sdk/rest/v3/tests/test_integration.py
@@ -52,6 +52,11 @@ from lnmarkets_sdk.rest.v3.models.synthetic_usd import GetSwapsParams, NewSwapPa
 
 load_dotenv()
 
+# Minimum signet balance (sats) to run trading tests. Below this, the spending
+# tests skip with a clear "top up the faucet" message instead of failing with
+# opaque insufficient-margin / rejected-order errors.
+MIN_TRADING_BALANCE = 500_000
+
 
 # Add delay between tests to avoid rate limiting
 @pytest.fixture
@@ -81,6 +86,77 @@ def create_auth_config() -> APIClientConfig:
             passphrase=os.environ.get("SIGNET_API_PASSPHRASE", "test-passphrase"),
         ),
     )
+
+
+@pytest.fixture(scope="session")
+def signet_balance() -> int | None:
+    """Fetch the account balance once per session (None if no credentials).
+
+    Runs in its own event loop via ``asyncio.run`` so it stays a plain sync
+    fixture, sidestepping pytest-asyncio's function-scoped loop.
+    """
+    if not os.environ.get("SIGNET_API_KEY"):
+        return None
+
+    async def _fetch() -> int:
+        async with LNMClient(create_auth_config()) as client:
+            account = await client.account.get_account()
+            return account.balance
+
+    return asyncio.run(_fetch())
+
+
+@pytest.fixture
+def require_funds(signet_balance: int | None) -> None:
+    """Skip a spending test when the signet balance is below the floor."""
+    # None => no credentials; the test's own skipif already handles that.
+    if signet_balance is not None and signet_balance < MIN_TRADING_BALANCE:
+        pytest.skip(
+            f"signet balance {signet_balance} < {MIN_TRADING_BALANCE} sats; "
+            "top up via the signet faucet"
+        )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_signet_state():
+    """Reconcile signet state after the whole suite runs (pass or fail).
+
+    Cancels resting orders/trades, closes running trades and the cross
+    position, and returns cross margin to the main balance so leftovers from
+    one run don't skew the next. Every step is best-effort: a failure here must
+    never fail the suite.
+    """
+    yield
+    if not os.environ.get("SIGNET_API_KEY"):
+        return
+
+    async def _cleanup() -> None:
+        async with LNMClient(create_auth_config()) as client:
+            # Cancel resting limit orders/trades that never filled.
+            with contextlib.suppress(APIException):
+                await client.futures.isolated.cancel_all()
+            with contextlib.suppress(APIException):
+                await client.futures.cross.cancel_all()
+            # Close any running isolated trades individually.
+            with contextlib.suppress(APIException):
+                for trade in await client.futures.isolated.get_running_trades():
+                    with contextlib.suppress(APIException):
+                        await client.futures.isolated.close(
+                            CloseTradeParams(id=trade.id)
+                        )
+            # Close the cross position, then withdraw its freed margin back to
+            # the main balance so deposits don't accumulate across runs.
+            with contextlib.suppress(APIException):
+                await client.futures.cross.close()
+            with contextlib.suppress(APIException):
+                position = await client.futures.cross.get_position()
+                if position.margin > 0:
+                    await client.futures.cross.withdraw(
+                        WithdrawParams(amount=position.margin)
+                    )
+
+    with contextlib.suppress(Exception):
+        asyncio.run(_cleanup())
 
 
 @pytest.mark.asyncio
@@ -370,6 +446,7 @@ class TestFuturesIsolatedIntegration:
         not os.environ.get("SIGNET_API_KEY"),
         reason="SIGNET_API_KEY not set in environment",
     )
+    @pytest.mark.usefixtures("require_funds")
     async def test_new_trade(self):
         async with LNMClient(create_auth_config()) as client:
             params = FuturesOrder(
@@ -464,6 +541,7 @@ class TestFuturesIsolatedIntegration:
         not os.environ.get("SIGNET_API_KEY"),
         reason="SIGNET_API_KEY not set in environment",
     )
+    @pytest.mark.usefixtures("require_funds")
     async def test_cancel_trade(self):
         async with LNMClient(create_auth_config()) as client:
             # Create a trade first
@@ -503,6 +581,7 @@ class TestFuturesIsolatedIntegration:
         not os.environ.get("SIGNET_API_KEY"),
         reason="SIGNET_API_KEY not set in environment",
     )
+    @pytest.mark.usefixtures("require_funds")
     async def test_close_trade(self):
         async with LNMClient(create_auth_config()) as client:
             # Create a running trade first (market order)
@@ -699,6 +778,7 @@ class TestFuturesCrossIntegration:
         not os.environ.get("SIGNET_API_KEY"),
         reason="SIGNET_API_KEY not set in environment",
     )
+    @pytest.mark.usefixtures("require_funds")
     async def test_new_order(self):
         async with LNMClient(create_auth_config()) as client:
             params = FuturesCrossOrderLimit(
@@ -772,6 +852,7 @@ class TestFuturesCrossIntegration:
         not os.environ.get("SIGNET_API_KEY"),
         reason="SIGNET_API_KEY not set in environment",
     )
+    @pytest.mark.usefixtures("require_funds")
     async def test_cancel_order(self):
         async with LNMClient(create_auth_config()) as client:
             # Create an order first
@@ -827,6 +908,7 @@ class TestFuturesCrossIntegration:
         not os.environ.get("SIGNET_API_KEY"),
         reason="SIGNET_API_KEY not set in environment",
     )
+    @pytest.mark.usefixtures("require_funds")
     async def test_deposit(self):
         async with LNMClient(create_auth_config()) as client:
             params = DepositParams(amount=10_000)
@@ -961,6 +1043,7 @@ class TestSyntheticUSDIntegration:
         not os.environ.get("SIGNET_API_KEY"),
         reason="SIGNET_API_KEY not set in environment",
     )
+    @pytest.mark.usefixtures("require_funds")
     async def test_new_swap(self):
         async with LNMClient(create_auth_config()) as client:
             # Try to create a swap (may fail due to insufficient balance or other reasons)

--- a/src/lnmarkets_sdk/rest/v3/tests/test_integration.py
+++ b/src/lnmarkets_sdk/rest/v3/tests/test_integration.py
@@ -67,18 +67,18 @@ async def auth_rate_limit_delay():
 
 
 def create_public_config() -> APIClientConfig:
-    """Create config for testnet4."""
-    return APIClientConfig(network="testnet4")
+    """Create config for signet."""
+    return APIClientConfig(network="signet")
 
 
 def create_auth_config() -> APIClientConfig:
-    """Create authenticated config for testnet4."""
+    """Create authenticated config for signet."""
     return APIClientConfig(
-        network="testnet4",
+        network="signet",
         authentication=APIAuthContext(
-            key=os.environ.get("TESTNET4_API_KEY", "test-key"),
-            secret=os.environ.get("TESTNET4_API_KEY_SECRET", "test-secret"),
-            passphrase=os.environ.get("TESTNET4_API_KEY_PASSPHRASE", "test-passphrase"),
+            key=os.environ.get("SIGNET_API_KEY", "test-key"),
+            secret=os.environ.get("SIGNET_API_SECRET", "test-secret"),
+            passphrase=os.environ.get("SIGNET_API_PASSPHRASE", "test-passphrase"),
         ),
     )
 
@@ -106,8 +106,8 @@ class TestAccountIntegration:
     """Integration tests for account endpoints (require authentication)."""
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_account(self):
         async with LNMClient(create_auth_config()) as client:
@@ -124,8 +124,8 @@ class TestAccountIntegration:
                 assert isinstance(account.linking_public_key, str)
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_bitcoin_address(self):
         async with LNMClient(create_auth_config()) as client:
@@ -133,8 +133,8 @@ class TestAccountIntegration:
             assert result.address is not None
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_add_bitcoin_address(self):
         async with LNMClient(create_auth_config()) as client:
@@ -150,8 +150,8 @@ class TestAccountIntegration:
                 )
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_deposit_lightning(self):
         async with LNMClient(create_auth_config()) as client:
@@ -161,8 +161,8 @@ class TestAccountIntegration:
             assert result.payment_request.startswith("ln")
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_withdraw_lightning(self):
         async with LNMClient(create_auth_config()) as client:
@@ -177,8 +177,8 @@ class TestAccountIntegration:
                 assert "Send a correct BOLT 11 invoice" in str(e)
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_withdraw_on_chain(self):
         async with LNMClient(create_auth_config()) as client:
@@ -196,8 +196,8 @@ class TestAccountIntegration:
                 assert "Invalid address" in str(e)
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_lightning_deposits(self):
         async with LNMClient(create_auth_config()) as client:
@@ -221,8 +221,8 @@ class TestAccountIntegration:
                     assert isinstance(data[0].settled_at, str)
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_lightning_withdrawals(self):
         async with LNMClient(create_auth_config()) as client:
@@ -239,8 +239,8 @@ class TestAccountIntegration:
                 assert data[0].status in ["failed", "processed", "processing"]
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_on_chain_deposits(self):
         async with LNMClient(create_auth_config()) as client:
@@ -262,8 +262,8 @@ class TestAccountIntegration:
                 assert "HTTP 404: Not found" in str(e)
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_on_chain_withdrawals(self):
         async with LNMClient(create_auth_config()) as client:
@@ -367,8 +367,8 @@ class TestFuturesIsolatedIntegration:
     """Integration tests for isolated margin futures endpoints."""
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_new_trade(self):
         async with LNMClient(create_auth_config()) as client:
@@ -403,8 +403,8 @@ class TestFuturesIsolatedIntegration:
                 pytest.skip("Could not create a new trade: " + str(e))
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_open_trades(self):
         async with LNMClient(create_auth_config()) as client:
@@ -423,8 +423,8 @@ class TestFuturesIsolatedIntegration:
                 assert open_trade.leverage > 0
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_running_trades(self):
         async with LNMClient(create_auth_config()) as client:
@@ -440,8 +440,8 @@ class TestFuturesIsolatedIntegration:
                 assert running_trade.pl is not None
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_closed_trades(self):
         async with LNMClient(create_auth_config()) as client:
@@ -461,8 +461,8 @@ class TestFuturesIsolatedIntegration:
                 assert isinstance(closed_trade.closed_at, str)
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_cancel_trade(self):
         async with LNMClient(create_auth_config()) as client:
@@ -487,8 +487,8 @@ class TestFuturesIsolatedIntegration:
                 pytest.skip("No running trades to cancel")
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_cancel_all_trades(self):
         async with LNMClient(create_auth_config()) as client:
@@ -500,8 +500,8 @@ class TestFuturesIsolatedIntegration:
                 assert canceled.running is False
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_close_trade(self):
         async with LNMClient(create_auth_config()) as client:
@@ -527,8 +527,8 @@ class TestFuturesIsolatedIntegration:
                 assert len(str(e)) > 0
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_add_margin(self):
         async with LNMClient(create_auth_config()) as client:
@@ -553,8 +553,8 @@ class TestFuturesIsolatedIntegration:
             assert updated.margin >= trade.margin
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_cash_in(self):
         async with LNMClient(create_auth_config()) as client:
@@ -577,8 +577,8 @@ class TestFuturesIsolatedIntegration:
             assert updated.running is True
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_update_stoploss(self):
         async with LNMClient(create_auth_config()) as client:
@@ -610,8 +610,8 @@ class TestFuturesIsolatedIntegration:
                     )
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_update_takeprofit(self):
         async with LNMClient(create_auth_config()) as client:
@@ -646,8 +646,8 @@ class TestFuturesIsolatedIntegration:
                     )
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_funding_fees_isolated(self):
         async with LNMClient(create_auth_config()) as client:
@@ -672,8 +672,8 @@ class TestFuturesCrossIntegration:
     """Integration tests for cross margin futures."""
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_position(self):
         async with LNMClient(create_auth_config()) as client:
@@ -696,8 +696,8 @@ class TestFuturesCrossIntegration:
                 assert position.liquidation > 0
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_new_order(self):
         async with LNMClient(create_auth_config()) as client:
@@ -721,8 +721,8 @@ class TestFuturesCrossIntegration:
                 pytest.skip(f"Could not create order: {str(e)}")
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_open_orders(self):
         async with LNMClient(create_auth_config()) as client:
@@ -742,8 +742,8 @@ class TestFuturesCrossIntegration:
                 assert order.created_at is not None
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_filled_orders(self):
         async with LNMClient(create_auth_config()) as client:
@@ -769,8 +769,8 @@ class TestFuturesCrossIntegration:
                     assert isinstance(order.filled_at, str)
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_cancel_order(self):
         async with LNMClient(create_auth_config()) as client:
@@ -795,8 +795,8 @@ class TestFuturesCrossIntegration:
                 pytest.skip("No running orders to cancel")
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_cancel_all_orders(self):
         async with LNMClient(create_auth_config()) as client:
@@ -808,8 +808,8 @@ class TestFuturesCrossIntegration:
                 assert canceled.filled is False
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_close_position(self):
         async with LNMClient(create_auth_config()) as client:
@@ -824,8 +824,8 @@ class TestFuturesCrossIntegration:
                 pytest.skip("No position to close")
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_deposit(self):
         async with LNMClient(create_auth_config()) as client:
@@ -836,8 +836,8 @@ class TestFuturesCrossIntegration:
             assert position.leverage > 0
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_withdraw(self):
         async with LNMClient(create_auth_config()) as client:
@@ -853,8 +853,8 @@ class TestFuturesCrossIntegration:
                 pytest.skip("Insufficient margin to test withdraw")
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_set_leverage(self):
         async with LNMClient(create_auth_config()) as client:
@@ -864,8 +864,8 @@ class TestFuturesCrossIntegration:
             assert position.leverage == 50
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_transfers(self):
         async with LNMClient(create_auth_config()) as client:
@@ -882,8 +882,8 @@ class TestFuturesCrossIntegration:
                 assert transfers[0].time is not None
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_funding_fees_cross(self):
         async with LNMClient(create_auth_config()) as client:
@@ -937,8 +937,8 @@ class TestSyntheticUSDIntegration:
             assert result.bid_price > 0
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_get_swaps(self):
         async with LNMClient(create_auth_config()) as client:
@@ -958,8 +958,8 @@ class TestSyntheticUSDIntegration:
                 assert swaps[0].out_asset in ["BTC", "USD"]
 
     @pytest.mark.skipif(
-        not os.environ.get("TESTNET4_API_KEY"),
-        reason="TESTNET4_API_KEY not set in environment",
+        not os.environ.get("SIGNET_API_KEY"),
+        reason="SIGNET_API_KEY not set in environment",
     )
     async def test_new_swap(self):
         async with LNMClient(create_auth_config()) as client:

--- a/src/lnmarkets_sdk/rest/v3/tests/test_unit.py
+++ b/src/lnmarkets_sdk/rest/v3/tests/test_unit.py
@@ -11,8 +11,10 @@ import json
 from base64 import b64encode
 from urllib.parse import urlencode
 
+import pytest
 from pytest_httpx import HTTPXMock
 
+from lnmarkets_sdk.rest.v3._internal.models import APIException
 from lnmarkets_sdk.rest.v3._internal.utils import prepare_params
 from lnmarkets_sdk.rest.v3.http.client import (
     APIAuthContext,
@@ -40,6 +42,32 @@ def _auth_config() -> APIClientConfig:
             passphrase="test-passphrase",
         ),
     )
+
+
+def _retry_config(max_retries: int = 2) -> APIClientConfig:
+    """Auth config with tiny backoff delays so retry tests run fast."""
+    return APIClientConfig(
+        network="signet",
+        authentication=APIAuthContext(
+            key="test-key",
+            secret=SECRET,
+            passphrase="test-passphrase",
+        ),
+        max_retries=max_retries,
+        retry_base_delay=0.01,
+        retry_max_delay=0.02,
+    )
+
+
+def _no_wait_client(config: APIClientConfig) -> LNMClient:
+    """Build a client whose backoff sleeps for zero seconds (keeps tests fast)."""
+    client = LNMClient(config)
+    client._base_client._backoff = lambda _rs: 0.0  # type: ignore[assignment]
+    return client
+
+
+def _error_body(code: str, message: str) -> dict[str, str]:
+    return {"code": code, "message": message}
 
 
 def _running_trade_payload() -> dict[str, object]:
@@ -203,3 +231,100 @@ async def test_remove_takeprofit_uses_delete_with_query_params(
     assert request.url.path == "/v3/futures/isolated/trade/takeprofit"
     assert request.url.params["id"] == TRADE_ID
     assert request.read() == b""
+
+
+async def test_retries_on_503_then_succeeds(httpx_mock: HTTPXMock) -> None:
+    # First call flaps with the "Trading engine temporarily unavailable" 503,
+    # the retry then succeeds.
+    httpx_mock.add_response(
+        status_code=503,
+        json=_error_body(
+            "SERVICE_UNAVAILABLE", "Trading engine is temporarily unavailable"
+        ),
+    )
+    httpx_mock.add_response(json=[])
+
+    async with _no_wait_client(_retry_config()) as client:
+        result = await client.futures.cross.cancel_all()
+
+    assert result == []
+    # Two requests went out: the failed attempt and the successful retry.
+    assert len(httpx_mock.get_requests()) == 2
+
+
+async def test_retries_exhausted_raises_api_exception(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        status_code=503,
+        json=_error_body(
+            "SERVICE_UNAVAILABLE", "Trading engine is temporarily unavailable"
+        ),
+        is_reusable=True,
+    )
+
+    with pytest.raises(APIException, match="Trading engine is temporarily unavailable"):
+        async with _no_wait_client(_retry_config(max_retries=2)) as client:
+            await client.futures.cross.cancel_all()
+
+    # Initial attempt + 2 retries.
+    assert len(httpx_mock.get_requests()) == 3
+
+
+async def test_retry_re_signs_each_attempt(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        status_code=503,
+        json=_error_body("SERVICE_UNAVAILABLE", "unavailable"),
+    )
+    httpx_mock.add_response(json=[])
+
+    async with _no_wait_client(_retry_config()) as client:
+        await client.futures.cross.cancel_all()
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    # Every attempt carries a freshly built (re-signed) auth header.
+    for req in requests:
+        assert req.headers.get("lnm-access-signature")
+        assert req.headers.get("lnm-access-timestamp")
+
+
+async def test_retries_on_429_rate_limit(httpx_mock: HTTPXMock) -> None:
+    # 429 is retried; a Retry-After header is honored by the wait strategy.
+    httpx_mock.add_response(
+        status_code=429,
+        headers={"Retry-After": "0"},
+        json=_error_body("TOO_MANY_REQUESTS", "rate limited"),
+    )
+    httpx_mock.add_response(json=[])
+
+    async with _no_wait_client(_retry_config()) as client:
+        result = await client.futures.cross.cancel_all()
+
+    assert result == []
+    assert len(httpx_mock.get_requests()) == 2
+
+
+async def test_non_retryable_status_is_not_retried(httpx_mock: HTTPXMock) -> None:
+    # A 400 is a client error: raise immediately, no retry.
+    httpx_mock.add_response(
+        status_code=400,
+        json=_error_body("BAD_REQUEST", "invalid params"),
+    )
+
+    with pytest.raises(APIException, match="invalid params"):
+        async with _no_wait_client(_retry_config()) as client:
+            await client.futures.cross.cancel_all()
+
+    assert len(httpx_mock.get_requests()) == 1
+
+
+async def test_max_retries_zero_disables_retry(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        status_code=503,
+        json=_error_body("SERVICE_UNAVAILABLE", "unavailable"),
+    )
+
+    with pytest.raises(APIException, match="unavailable"):
+        async with _no_wait_client(_retry_config(max_retries=0)) as client:
+            await client.futures.cross.cancel_all()
+
+    assert len(httpx_mock.get_requests()) == 1

--- a/src/lnmarkets_sdk/rest/v3/tests/test_unit.py
+++ b/src/lnmarkets_sdk/rest/v3/tests/test_unit.py
@@ -33,7 +33,7 @@ SECRET = "test-secret"
 
 def _auth_config() -> APIClientConfig:
     return APIClientConfig(
-        network="testnet4",
+        network="signet",
         authentication=APIAuthContext(
             key="test-key",
             secret=SECRET,

--- a/src/lnmarkets_sdk/stream/v1/__init__.py
+++ b/src/lnmarkets_sdk/stream/v1/__init__.py
@@ -18,7 +18,7 @@ from lnmarkets_sdk.stream.v1.models import (
 )
 
 async def main():
-    config = StreamClientConfig(network="testnet4")
+    config = StreamClientConfig(network="signet")
     async with StreamClient(config) as client:
         await client.connect()
         await client.auth.authenticate(

--- a/src/lnmarkets_sdk/stream/v1/_internal/models.py
+++ b/src/lnmarkets_sdk/stream/v1/_internal/models.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic.alias_generators import to_camel
 
-type StreamNetwork = Literal["mainnet", "testnet4"]
+type StreamNetwork = Literal["mainnet", "signet"]
 type ConnectionState = Literal[
     "disconnected", "connecting", "connected", "reconnecting"
 ]

--- a/src/lnmarkets_sdk/stream/v1/_internal/utils.py
+++ b/src/lnmarkets_sdk/stream/v1/_internal/utils.py
@@ -18,8 +18,8 @@ from .models import StreamAuthContext, StreamNetwork, StreamValidationException
 def get_hostname(network: StreamNetwork) -> str:
     """Stream API hostname for the given network."""
     return (
-        "stream.testnet4.lnmarkets.com"
-        if network == "testnet4"
+        "stream.signet.lnmarkets.com"
+        if network == "signet"
         else "stream.lnmarkets.com"
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -196,7 +196,7 @@ wheels = [
 
 [[package]]
 name = "lnmarkets-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -196,7 +196,7 @@ wheels = [
 
 [[package]]
 name = "lnmarkets-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -204,6 +204,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pygments" },
     { name = "requests" },
+    { name = "tenacity" },
     { name = "websockets" },
 ]
 
@@ -235,6 +236,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.2" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "requests", specifier = ">=2.32.3" },
+    { name = "tenacity", specifier = ">=9.1.4" },
     { name = "websockets", specifier = ">=12.0" },
 ]
 
@@ -541,6 +543,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Migrate from testnet4 to signet
- Bump version from 0.1.3 to 0.1.4
- Adjust CI
- Add backoff retry for integration test
- Add funds guard so that funds never ran out in tests
- Update CHANGELOG.md